### PR TITLE
Fix hexadecimal output of stat

### DIFF
--- a/check_diskstat.sh
+++ b/check_diskstat.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Original Author: Unknown
 #
+# Changes: 05-Nov-2014 Michal Svamberg <svamberg@civ.zcu.cz>
+#          Fix when too much devices, translate hex output of stat to decimal
 # Changes: 12-Jul-2013 Mark Clarkson <mark.clarkson@smorg.co.uk>
 #          Added support for logical volume names.
 # Changes: 25-Feb-2013 Mark Clarkson <mark.clarkson@smorg.co.uk>
@@ -138,7 +140,8 @@ if [ ! -e /sys/block/$DISK/stat ]; then
     # The device does not exist.
     if [[ $ORIGDISK =~ "/" && -b /dev/$ORIGDISK ]]; then
         # The minor device no. maps to /dev/dm-N
-        MINOR=`stat -L /dev/$ORIGDISK --printf="%T\n"`
+        MINOR_HEX=`stat -L /dev/$ORIGDISK --printf="%T\n"`
+        MINOR=`echo $((16#$MINOR_HEX))` # translate hex output to decimal
         [[ $? -ne 0 ]] && {
             echo "Could not stat '/dev/$ORIGDISK', check your /sys filesystem for $DISK"
             exit $E_UNKNOWN


### PR DESCRIPTION
The number in /dev/dm-NUM is not hexadecimal, but command stat prints minor number in hexadecimal. This is problem when using more then 9 devices. 
Bug Nr.1: Script reads information from other device (12 in hexa is 18 in decimal) with lower minor number!
Bug Nr.2: Command stat return minor number 'ff', but in hexa is FF and device /dev/dm-ff does not exists (/dev/dm-255 is correct).

Example of bug Nr.1:

<pre>
# ls -l /dev/mapper/vgxen-daphne.root
lrwxrwxrwx 1 root root 8 Oct 16 01:23 /dev/mapper/vgxen-daphne.root -> ../dm-17
# ls -l /dev/dm-`stat -L /dev/mapper/vgxen-daphne.root --printf="%T\n"`
brw-rw---T 1 root disk 253, 11 Oct 16 01:23 /dev/dm-11
</pre>


Example of bug Nr.2:

<pre>
 # ls -l /dev/dm-`stat -L /dev/mapper/fc-p1-xen-data-mirror --printf="%T\n"`
 ls: cannot access /dev/dm-ff: No such file or directory
</pre>
