### PR TITLE
Removed units from performance data

### DIFF
--- a/check_diskstat.sh
+++ b/check_diskstat.sh
@@ -330,9 +330,9 @@ do
 done
 
 if [[ $BRIEF -eq 0 ]]; then
-    echo "${OUTPUT}summary: $TPS io/s, read $SECTORS_READ sectors (${KBYTES_READ_PER_SEC}kB/s), write $SECTORS_WRITE sectors (${KBYTES_WRITTEN_PER_SEC}kB/s), queue size $AQUSZ in $TIME seconds | tps=${TPS}io/s;$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC}b/s;$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC}b/s;$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT}ms;;;"
+    echo "${OUTPUT}summary: $TPS io/s, read $SECTORS_READ sectors (${KBYTES_READ_PER_SEC}kB/s), write $SECTORS_WRITE sectors (${KBYTES_WRITTEN_PER_SEC}kB/s), queue size $AQUSZ in $TIME seconds | tps=${TPS};$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC};$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC};$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT};;;"
 else
-    echo "$TPS io/s, read ${KBYTES_READ_PER_SEC}kB/s, write ${KBYTES_WRITTEN_PER_SEC}kB/s, ave. queue size ${AQUSZ} | tps=${TPS}io/s;$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC}b/s;$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC}b/s;$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT}ms;;;"
+    echo "$TPS io/s, read ${KBYTES_READ_PER_SEC}kB/s, write ${KBYTES_WRITTEN_PER_SEC}kB/s, ave. queue size ${AQUSZ} | tps=${TPS};$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC};$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC};$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT};;;"
 fi
 
 if [[ $SILENT -eq 1 ]]; then

--- a/check_diskstat.sh
+++ b/check_diskstat.sh
@@ -330,9 +330,9 @@ do
 done
 
 if [[ $BRIEF -eq 0 ]]; then
-    echo "${OUTPUT}summary: $TPS io/s, read $SECTORS_READ sectors (${KBYTES_READ_PER_SEC}kB/s), write $SECTORS_WRITE sectors (${KBYTES_WRITTEN_PER_SEC}kB/s), queue size $AQUSZ in $TIME seconds | tps=${TPS};$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC};$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC};$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT};;;"
+    echo "${OUTPUT}summary: $TPS io/s, read $SECTORS_READ sectors (${KBYTES_READ_PER_SEC}kB/s), write $SECTORS_WRITE sectors (${KBYTES_WRITTEN_PER_SEC}kB/s), queue size $AQUSZ in $TIME seconds | tps=${TPS};$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC};$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC};$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT}ms;;;"
 else
-    echo "$TPS io/s, read ${KBYTES_READ_PER_SEC}kB/s, write ${KBYTES_WRITTEN_PER_SEC}kB/s, ave. queue size ${AQUSZ} | tps=${TPS};$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC};$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC};$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT};;;"
+    echo "$TPS io/s, read ${KBYTES_READ_PER_SEC}kB/s, write ${KBYTES_WRITTEN_PER_SEC}kB/s, ave. queue size ${AQUSZ} | tps=${TPS};$WARN_TPS;$CRIT_TPS; read=${BYTES_READ_PER_SEC};$WARN_READ;$CRIT_READ; write=${BYTES_WRITTEN_PER_SEC};$WARN_WRITE;$CRIT_WRITE; avgrq-sz=${ARQSZ};;; avgqu-sz=${AQUSZ};$WARN_QSZ;$CRIT_QSZ; await=${AWAIT}ms;;;"
 fi
 
 if [[ $SILENT -eq 1 ]]; then


### PR DESCRIPTION
For using the performance data with icinga2 and graphite / influx, the performance data output should not contain units like io/s or mb/s. see https://docs.icinga.com/latest/en/perfdata.html